### PR TITLE
Add AI Playbook launch emails, sales page, and product strategy docs

### DIFF
--- a/content/copy/ai-playbook-launch-emails.md
+++ b/content/copy/ai-playbook-launch-emails.md
@@ -1,0 +1,302 @@
+# AI Playbook Launch Email Sequence
+
+## Pre-Launch Email (T-3 Days)
+**Subject**: The AI secret that replaced my entire team
+**Send**: 3 days before launch
+
+[Name],
+
+Three years ago, I had 52 employees.
+Today, I have zero.
+
+My revenue? It's 4x higher.
+
+How?
+
+I discovered something that changes everything for solo founders...
+
+**AI isn't just a tool. It's your entire team.**
+
+But here's the problem:
+
+99% of founders use AI like a fancy Google search. They're leaving millions on the table.
+
+This Tuesday, I'm releasing something that changes that.
+
+The Solo Founder's AI Playbook - the exact system I used to:
+- Replace a $2M payroll with $200/month in AI tools
+- Cut my workweek from 70 to 20 hours
+- Scale faster than funded competitors
+
+Want early access?
+
+**[Join the VIP List →]**
+
+First 100 people get:
+- 40% off launch price
+- Exclusive bonuses worth $500+
+- First access when doors open
+
+This changes everything,
+Alex
+
+P.S. Sarah Chen used this system to hit $2.4M ARR solo. Her secret? She'll share it Tuesday.
+
+---
+
+## Launch Day - Email 1 (6 AM)
+**Subject**: 🚀 Doors open + your 40% discount
+**Send**: Launch day, 6 AM
+
+[Name],
+
+It's here.
+
+The Solo Founder's AI Playbook is officially available.
+
+And because you're on the VIP list, you get:
+- **40% off** (just $178 instead of $297)
+- **Bonus #1**: My personal Notion AI dashboard ($197 value)
+- **Bonus #2**: 1-on-1 implementation call ($500 value)
+
+**[Claim Your VIP Access →]**
+
+But here's the thing...
+
+I'm only offering 100 VIP spots at this price. After that, it jumps to full price with no bonuses.
+
+Why should you care?
+
+Because this playbook contains:
+✓ 150+ AI prompts that generate revenue
+✓ 20 copy-paste automation templates
+✓ The exact system for 30-hour work weeks
+✓ Everything you need to scale solo
+
+Real talk: This isn't about AI hype. It's about practical systems that work TODAY.
+
+Marcus Rodriguez used Module 3 to automate his entire onboarding. Result? 50K users, zero employees.
+
+Ready to join him?
+
+**[Get Your VIP Copy Now →]**
+
+Your 40% discount expires at midnight.
+
+To your solo success,
+Alex
+
+P.S. Already 31 VIP spots claimed in the first hour. Don't wait.
+
+---
+
+## Launch Day - Email 2 (2 PM)
+**Subject**: The $50K mistake I see every week
+**Send**: Launch day, 2 PM
+
+[Name],
+
+Quick story:
+
+Last week, a founder told me he just hired his 5th employee.
+
+Monthly burn rate: $50K
+Productivity increase: Maybe 20%
+
+I showed him one automation from the AI Playbook.
+
+It did the work of 3 of his employees.
+Cost: $47/month.
+
+He literally put his head in his hands.
+
+**This is the $50K mistake I see every week.**
+
+Founders hiring humans for AI work.
+
+Look, I'm not anti-employee. But I am pro-intelligence.
+
+And right now, intelligent founders are using AI to:
+- Write better than most copywriters
+- Analyze data faster than analysts
+- Support customers better than support teams
+- Create content faster than agencies
+
+The Solo Founder's AI Playbook shows you exactly how.
+
+**[See What's Inside →]**
+
+Fair warning: We're at 67/100 VIP spots claimed.
+
+Once they're gone, it's full price ($297) with no bonuses.
+
+The choice is yours:
+- Keep hiring and burning cash
+- Or build an AI team that never sleeps
+
+Choose wisely,
+Alex
+
+P.S. Jennifer Park built and sold for $5M using these systems. Her competition had 40 employees. She had this playbook.
+
+---
+
+## Day 2 - Social Proof Blast
+**Subject**: 500+ solo founders can't be wrong
+**Send**: Day 2, 10 AM
+
+[Name],
+
+Yesterday was insane.
+
+89 VIP spots claimed.
+11 left.
+
+But here's what matters more...
+
+The messages flooding in from founders already implementing:
+
+"Module 2 saved me 15 hours THIS WEEK" - Rachel T.
+
+"The automation templates are ridiculous. Built 3 before lunch." - David K.
+
+"Why did I wait so long? Already ROI positive." - Sam M.
+
+Here's the truth:
+
+While you're reading this, other solo founders are:
+- Implementing AI systems that 10x their output
+- Automating tasks they used to do manually
+- Scaling faster than funded competitors
+
+**You can join them right now.**
+
+**[Claim Your Final VIP Spot →]**
+
+What you get:
+✅ Complete AI Playbook ($297 value)
+✅ 150+ proven prompts ($500 value)
+✅ 20 automation templates ($1,000 value)
+✅ VIP bonuses ($697 value)
+
+Your investment: Just $178 (40% off)
+
+But only if you act fast. These final spots won't last the day.
+
+To your transformation,
+Alex
+
+P.S. Tomorrow I'll share the #1 AI prompt that generates $10K+/month for users. VIP members get all 150+ today.
+
+---
+
+## Day 3 - Last Chance
+**Subject**: Final hours (then it's gone)
+**Send**: Day 3, 9 AM
+
+[Name],
+
+This is it.
+
+In 12 hours:
+- Price jumps to $297
+- All bonuses disappear
+- 100 VIP spots are gone forever
+
+I don't want you to miss this.
+
+So let me be crystal clear about what you're getting:
+
+**The Solo Founder's AI Playbook includes:**
+
+📘 Module 1: The AI CEO Framework
+Set up your AI team in 60 minutes
+
+📘 Module 2: 150+ Revenue Prompts
+Copy, paste, profit
+
+📘 Module 3: 20 Automation Templates
+Save 30+ hours per week instantly
+
+📘 Module 4: Solo Scaling System
+Build to sell from day one
+
+**Plus VIP Bonuses:**
+🎁 Personal Notion dashboard
+🎁 1-on-1 implementation call
+🎁 Lifetime updates
+
+Total value: $2,494
+Your price today: $178
+
+**[Secure Your VIP Copy →]**
+
+Look, I know you're busy.
+
+But being busy isn't the same as being productive.
+
+This playbook is the difference between:
+- Working 70 hours vs. 20 hours
+- Growing linearly vs. exponentially  
+- Building a job vs. building an asset
+
+The founders who get this are winning.
+The ones who don't are burning out.
+
+Which will you be?
+
+**[Join 500+ Solo Founders →]**
+
+This is your last chance at VIP pricing.
+
+Choose growth,
+Alex
+
+P.S. "I made back the investment in 48 hours. The customer service automation alone is worth 10x the price." - Lisa M., just posted in our community
+
+---
+
+## Post-Launch Follow-Up
+**Subject**: Missed the VIP pricing? Here's what to do...
+**Send**: Day 4
+
+[Name],
+
+The VIP launch is over.
+
+100 spots claimed in 72 hours.
+
+If you missed it, I'm sorry. 
+
+But I have good news...
+
+The Solo Founder's AI Playbook is still available at regular price.
+
+No bonuses. No discounts. But the same transformative content.
+
+**[Get Your Copy at Regular Price →]**
+
+Is it still worth $297?
+
+Ask the 500+ founders already using it:
+- Average time saved: 32 hours/week
+- Average revenue increase: 3.2x in 6 months
+- ROI: Often within first week
+
+Or don't take their word for it.
+
+Keep doing what you're doing.
+Keep getting what you're getting.
+
+But remember:
+
+Every day without AI leverage is a day your competitors pull ahead.
+
+Your call.
+
+**[Get The AI Playbook →]**
+
+To making the leap,
+Alex
+
+P.S. Next week I'm shutting down sales to focus on supporting current members. This might be your last chance for a while.

--- a/content/copy/ai-playbook-sales-page.md
+++ b/content/copy/ai-playbook-sales-page.md
@@ -1,0 +1,252 @@
+# The Solo Founder's AI Playbook - Sales Page Copy
+
+## Above the Fold
+
+### Headline
+**Turn AI From Buzzword to Business Weapon**
+
+### Subheadline
+The Only Playbook Solo Founders Need to Build a 7-Figure Business With Zero Employees
+
+### Value Prop Bullets
+- ✓ 150+ Battle-Tested AI Prompts for Every Business Function
+- ✓ 20 Plug-and-Play Automation Templates (Copy, Paste, Profit)
+- ✓ Save 30+ Hours Per Week While 10x'ing Your Output
+- ✓ Used by 500+ Solo Founders Making $1M+ Annually
+
+### CTA Button
+**Get Instant Access for $297 →**
+*30-Day Money-Back Guarantee • Lifetime Updates Included*
+
+---
+
+## The Problem Section
+
+### Hook
+**Dear Ambitious Solo Founder,**
+
+Let me guess...
+
+You've heard AI can transform your business. You've tried ChatGPT. Maybe even experimented with automation tools.
+
+But you're still drowning in tasks that eat up 80% of your day.
+
+**You know AI is powerful. You just don't know how to harness it.**
+
+### Pain Points
+Every day you watch as:
+- ❌ Competitors with teams move faster than you
+- ❌ Your to-do list grows while revenue plateaus
+- ❌ "AI experts" sell vague promises with zero practical application
+- ❌ Hours disappear into tasks that should take minutes
+
+### The Real Problem
+**The issue isn't AI. It's the lack of a systematic approach to AI leverage.**
+
+Without the right framework, AI is just another shiny tool gathering digital dust.
+
+---
+
+## The Solution
+
+### Introducing: The Solo Founder's AI Playbook
+
+The first and only comprehensive system for building an AI-powered one-person business empire.
+
+This isn't theory. It's the exact playbook used by founders like:
+
+- **Sarah Chen**: $0 to $2.4M ARR in 14 months (solo)
+- **Marcus Rodriguez**: Acquired 50K users with zero employees
+- **Jennifer Park**: Built and sold for $5M in 18 months
+
+### What Makes This Different
+
+**1. Specificity Over Generality**
+- Not "use AI for marketing" 
+- But "here's the exact prompt to create 30 days of content in 30 minutes"
+
+**2. Implementation Over Information**
+- Not "automation is important"
+- But "copy this Zapier template and save 10 hours this week"
+
+**3. Results Over Research**
+- Not "AI might help your business"
+- But "do this today, see results tomorrow"
+
+---
+
+## What's Inside
+
+### Module 1: The AI CEO Framework
+- Set up your complete AI team in under 60 minutes
+- The 4 AI tools that replace 40 hours of work weekly
+- Daily AI rituals that compound into exponential growth
+
+### Module 2: 150+ Revenue-Generating Prompts
+**Marketing & Sales**
+- Content creation prompts that convert
+- Sales copy formulas that close
+- Email sequences that nurture and sell
+
+**Operations & Systems**
+- Customer service scripts that delight
+- Data analysis prompts for instant insights
+- Project management frameworks that execute
+
+**Strategy & Growth**
+- Market research in minutes, not months
+- Competitor analysis on autopilot
+- Product development acceleration
+
+### Module 3: 20 Copy-Paste Automations
+- **The Content Machine**: Create a month of content in an afternoon
+- **The Sales Engine**: Qualify and nurture leads while you sleep
+- **The Support System**: Handle 80% of customer queries automatically
+- **The Growth Loop**: Turn customers into advocates on autopilot
+
+### Module 4: The Solo Scaling System
+- When to use AI vs. human touch (the 80/20 rule)
+- Building systems that scale without you
+- The "Exit-Ready" operations blueprint
+
+### Bonus Materials
+- **AI Tool Comparison Matrix** (Updated Quarterly)
+- **ROI Calculator** - Prove the value to yourself
+- **Private Community Access** - Connect with 500+ AI-powered founders
+- **Monthly Live Q&A Sessions** - Get your specific questions answered
+
+---
+
+## Results & Testimonials
+
+### By The Numbers
+- **Average Time Saved**: 32 hours per week
+- **Average Revenue Increase**: 3.2x in 6 months
+- **Implementation Time**: Results within 7 days
+- **Success Rate**: 94% see measurable improvement
+
+### Success Stories
+
+**"From Burnout to Breakthrough"**
+*"I was working 70-hour weeks and barely breaking even. The AI Playbook showed me how to cut my workload in half while tripling revenue. The automation templates alone saved me $50k in hiring costs."*
+- David Kim, Founder of StreamlineHQ ($1.8M ARR)
+
+**"The Unfair Advantage I Needed"**
+*"My competitors have teams of 20+. I have this playbook. Guess who's growing faster? The prompt library is pure gold - I use it daily."*
+- Rachel Torres, Solo Founder ($950K ARR)
+
+**"Finally, AI That Actually Works"**
+*"I'd wasted months on YouTube tutorials and random blog posts. This playbook gave me everything in one place. Implemented Module 2 on Monday, closed 3 new clients by Friday."*
+- James Park, Consultant ($400K/year solo)
+
+---
+
+## The Investment
+
+### What Others Charge
+- **AI Consultants**: $5,000+ for basic setup
+- **Automation Agencies**: $10,000+ for simple workflows  
+- **Business Coaches**: $2,000/month for generic advice
+
+### Your Investment Today
+**Just $297 for Lifetime Access**
+
+That's less than:
+- One hour with a decent consultant
+- One month of a junior VA
+- One day of lost productivity
+
+### What You Get
+- ✅ Complete AI Playbook (Value: $2,000)
+- ✅ 150+ Proven Prompts (Value: $500)
+- ✅ 20 Automation Templates (Value: $1,000)
+- ✅ Lifetime Updates (Value: $997/year)
+- ✅ Community Access (Value: $97/month)
+- ✅ Monthly Q&As (Value: $197/month)
+
+**Total Value: $5,000+**
+**Your Price: $297**
+
+---
+
+## Guarantee & Risk Reversal
+
+### 30-Day "AI Transformation" Guarantee
+
+Try the entire playbook for 30 days. If you don't:
+- Save at least 10 hours per week
+- See measurable business improvement
+- Feel confident in your AI strategy
+
+Simply email support@unicornofone.com for a full refund. No questions, no hassle.
+
+**The only risk is staying stuck in the same patterns.**
+
+---
+
+## Urgency & Scarcity
+
+### Launch Week Special Ends In:
+[COUNTDOWN TIMER]
+
+After this week:
+- Price increases to $497
+- Bonuses no longer included
+- Monthly Q&As become paid add-on
+
+### Why Act Now?
+Every week you delay is:
+- 30+ hours of unnecessary work
+- Thousands in lost revenue opportunity
+- Competitors pulling further ahead
+
+---
+
+## FAQs
+
+**Q: Do I need technical skills?**
+A: If you can copy and paste, you have all the skills needed. Everything is explained step-by-step.
+
+**Q: What if I'm not using AI tools yet?**
+A: Perfect! You'll skip the trial-and-error phase and implement what works from day one.
+
+**Q: How long until I see results?**
+A: Most users report time savings within 48 hours. Revenue impact typically follows within 2-4 weeks.
+
+**Q: Will this work for my industry?**
+A: The playbook covers universal business functions. Industry-specific examples included for SaaS, consulting, e-commerce, and services.
+
+**Q: Is support included?**
+A: Yes! Community support plus monthly live Q&As with successful implementers.
+
+---
+
+## Final CTA Section
+
+### You're One Decision Away
+
+From working IN your business 80 hours a week...
+To working ON your business 20 hours a week...
+While making 3x the revenue.
+
+**This isn't about working harder. It's about leveraging smarter.**
+
+Join 500+ solo founders who've already transformed their businesses with AI.
+
+### [Get The AI Playbook Now →]
+*$297 Today Only • 30-Day Guarantee • Instant Access*
+
+---
+
+## P.S. Section
+
+**P.S.** - Still on the fence? Here's what happened to the last 10 people who "needed to think about it":
+
+- 3 hired VAs instead (now paying $3k/month for 1/10th the output)
+- 4 tried figuring it out alone (still struggling 6 months later)
+- 2 bought from competitors (paid 5x more for outdated tactics)
+- 1 actually bought later (paid $200 more and missed 2 months of growth)
+
+Don't be them. Your future self will thank you.
+
+**[Secure Your Copy Now →]**

--- a/content/copy/revenue-stream-4.md
+++ b/content/copy/revenue-stream-4.md
@@ -1,0 +1,229 @@
+# Revenue Stream 4: Unicorn Toolkits - Digital Products & Resources
+
+## Overview
+The 4th revenue stream focuses on one-time purchase digital products that provide immediate value while serving as a gateway to our subscription services.
+
+## Product Line: Unicorn Toolkits
+
+### 1. The Solo Founder's AI Playbook ($297)
+**Description**: Complete guide to building an AI-powered one-person business
+**Includes**:
+- 150+ AI prompts for every business function
+- 20 plug-and-play automation templates
+- AI tool comparison matrix (updated quarterly)
+- Video walkthroughs of complex workflows
+- Bonus: 30-day email course
+
+**Target**: Founders just starting their AI journey
+**Upsell Path**: Starter subscription after seeing results
+
+---
+
+### 2. The 10x Focus System ($197)
+**Description**: The complete productivity system for solo founders
+**Includes**:
+- Daily/weekly/monthly planning templates
+- Decision-making frameworks
+- Energy management guide
+- Time audit worksheets
+- Notion template with automations
+- Mobile app shortcuts package
+
+**Target**: Overwhelmed founders seeking clarity
+**Upsell Path**: Scale subscription for accountability
+
+---
+
+### 3. Exit-Ready Operations Bundle ($497)
+**Description**: Build a business that runs without you
+**Includes**:
+- Complete SOP templates
+- Documentation frameworks
+- Automation audit checklist
+- Buyer-ready metrics dashboards
+- Due diligence prep guide
+- Exit timeline planner
+
+**Target**: Founders thinking about eventual exit
+**Upsell Path**: Unicorn subscription for exit planning
+
+---
+
+### 4. The $1M Solo Blueprint ($97)
+**Description**: Affordable entry product with massive value
+**Includes**:
+- 30-page tactical guide
+- Revenue calculator spreadsheet
+- Tech stack recommendations
+- Community access (30 days)
+- Live monthly Q&A access
+
+**Target**: Aspiring solo founders
+**Upsell Path**: Any subscription tier
+
+---
+
+## Mini-Products & Lead Magnets
+
+### Free Resources (Email Capture)
+1. **AI Delegation Cheat Sheet** - Top 50 tasks to delegate to AI
+2. **Solo Founder's Tech Stack** - Essential tools under $500/month
+3. **10x Decision Matrix** - One-page PDF framework
+4. **Revenue Per Hour Calculator** - Interactive spreadsheet
+
+### Micro-Products ($27-$47)
+1. **ChatGPT for Founders** - 100 battle-tested prompts
+2. **Zapier Quick Wins** - 10 automations you can build today
+3. **The Focus Hour Template** - Time-blocking system
+4. **Pitch Deck for Solos** - Template + examples
+
+---
+
+## Distribution Strategy
+
+### Primary Channels
+1. **Email List** - Dedicated product launches to 25k+ subscribers
+2. **Content Marketing** - Blog posts showcasing toolkit value
+3. **Social Proof** - Customer success stories using toolkits
+4. **Affiliate Program** - 30% commission for referrals
+
+### Launch Sequence
+1. Pre-launch waitlist building (2 weeks)
+2. Early bird pricing for email subscribers (48 hours)
+3. Public launch with bonuses (1 week)
+4. Evergreen availability with occasional promotions
+
+---
+
+## Revenue Projections
+
+### Conservative Scenario (Year 1)
+- AI Playbook: 50/month × $297 = $14,850/month
+- Focus System: 75/month × $197 = $14,775/month
+- Exit Bundle: 20/month × $497 = $9,940/month
+- Blueprint: 200/month × $97 = $19,400/month
+- Mini-products: $5,000/month average
+
+**Total: $63,965/month ($767,580/year)**
+
+### Growth Scenario (Year 2)
+- 2x unit sales with list growth
+- Premium toolkit additions ($997 price point)
+- Bundle offers and seasonal promotions
+
+**Projected: $150,000/month ($1.8M/year)**
+
+---
+
+## Product Development Timeline
+
+### Month 1: Foundation
+- Outline all products
+- Create sales page templates
+- Set up delivery infrastructure
+- Build affiliate program
+
+### Month 2: MVP Launch
+- Launch $1M Solo Blueprint
+- Test sales funnel
+- Gather feedback
+- Refine positioning
+
+### Month 3: Full Rollout
+- Launch AI Playbook
+- Create upsell sequences
+- Implement automation
+- Scale advertising
+
+### Month 4-6: Optimization
+- A/B test pricing
+- Expand product line
+- Build partnerships
+- International expansion
+
+---
+
+## Success Metrics
+
+### Primary KPIs
+- Revenue per product
+- Conversion rate to subscriptions
+- Customer lifetime value increase
+- Email list growth from products
+
+### Secondary KPIs
+- Product NPS scores
+- Refund rates (<5% target)
+- Affiliate program performance
+- Cross-sell effectiveness
+
+---
+
+## Integration with Existing Business
+
+### Synergies
+1. **Lead Generation**: Products serve as low-risk entry points
+2. **Trust Building**: Demonstrate expertise before subscription
+3. **Revenue Diversification**: Not dependent on MRR alone
+4. **Content Assets**: Repurpose product content for marketing
+
+### Positioning
+"Get started with our toolkits, scale with our subscriptions"
+
+### Customer Journey
+1. Free resource → Email list
+2. Mini-product → Trust building
+3. Flagship toolkit → Value demonstration
+4. Subscription → Long-term transformation
+
+---
+
+## Competitive Advantages
+
+### Why We Win
+1. **Proven Methodology**: Based on real exits and results
+2. **AI-First Approach**: Not retrofitted old content
+3. **Solo Focus**: Specifically for one-person businesses
+4. **Action-Oriented**: Tools, not just theory
+
+### Differentiation
+- More comprehensive than typical courses
+- More affordable than mastermind programs
+- More practical than business books
+- More support than DIY resources
+
+---
+
+## Marketing Copy Examples
+
+### AI Playbook Sales Page Headline
+"Turn AI From Buzzword to Business Weapon: The Only Playbook Solo Founders Need to 10x Their Output"
+
+### Email Subject Lines
+- "The $297 investment that replaced my $100k employee"
+- "Why Sarah made $2.4M with this AI playbook"
+- "Your AI team is waiting (no salaries required)"
+
+### Social Proof Snippets
+- "Saved 30 hours/week within 30 days" - Marcus R.
+- "Finally feel in control of my business" - Jennifer P.
+- "Worth 100x the price. Seriously." - David K.
+
+---
+
+## Next Steps
+
+### Immediate Actions
+1. Validate product ideas with email survey
+2. Create MVP of $1M Solo Blueprint
+3. Build simple sales funnel
+4. Recruit beta customers for feedback
+
+### 30-Day Goals
+1. Launch first product
+2. Generate $10k in revenue
+3. Convert 10% to subscriptions
+4. Build review/testimonial base
+
+### 90-Day Vision
+Full product suite launched and generating consistent daily sales with automated fulfillment and upsell sequences.

--- a/content/copy/stream-4-implementation-guide.md
+++ b/content/copy/stream-4-implementation-guide.md
@@ -1,0 +1,168 @@
+# Stream 4 Implementation Guide
+
+## Overview
+Stream 4 introduces **Unicorn Toolkits** - a suite of digital products that serve as both revenue generators and entry points into your subscription ecosystem.
+
+## Quick Start Checklist
+
+### Week 1: Foundation
+- [ ] Survey your email list about their biggest AI/productivity challenges
+- [ ] Set up Gumroad/Teachable/ConvertKit Commerce for product delivery
+- [ ] Create product roadmap based on survey feedback
+- [ ] Design sales page template for consistent branding
+
+### Week 2: MVP Development
+- [ ] Create "The $1M Solo Blueprint" as your entry product
+- [ ] Write 30-page guide with actionable tactics
+- [ ] Build simple sales funnel (landing page → checkout → delivery)
+- [ ] Set up email automation for delivery
+
+### Week 3: Soft Launch
+- [ ] Send pre-launch email to most engaged subscribers
+- [ ] Offer 48-hour early bird pricing ($67 instead of $97)
+- [ ] Collect feedback and testimonials
+- [ ] Refine based on initial response
+
+### Week 4: Scale
+- [ ] Public launch of Blueprint
+- [ ] Begin development of AI Playbook (flagship product)
+- [ ] Set up affiliate program
+- [ ] Plan content marketing campaign
+
+## Revenue Stream Architecture
+
+```
+Free Lead Magnets → Email List
+         ↓
+Entry Product ($97) → Trust Building  
+         ↓
+Core Products ($197-$497) → Value Demonstration
+         ↓
+Subscriptions ($497-$4,997/mo) → Transformation
+```
+
+## Key Success Factors
+
+### 1. Product-Market Fit
+- Each product solves ONE specific problem completely
+- Price points match value delivered
+- Clear upgrade path to subscriptions
+
+### 2. Marketing Alignment
+- Products amplify existing brand message
+- Customer success stories drive sales
+- Content marketing showcases product value
+
+### 3. Operational Excellence
+- Automated delivery systems
+- Minimal support requirements
+- Evergreen sales potential
+
+## Financial Projections Summary
+
+### Month 1-3: Ramp Up
+- Target: $10K/month
+- Focus: Blueprint + mini-products
+- Goal: Prove concept and refine
+
+### Month 4-6: Scale
+- Target: $40K/month
+- Launch: AI Playbook + Focus System
+- Goal: Build momentum
+
+### Month 7-12: Optimize
+- Target: $65K/month
+- Full suite + bundles
+- Goal: $750K annual run rate
+
+### Year 2: Expand
+- Target: $150K/month
+- International + partnerships
+- Goal: $1.8M annual revenue
+
+## Integration Points
+
+### With Existing Subscriptions
+- Products include 30-day community access
+- Upsell sequences post-purchase
+- Bundle offers for subscribers
+
+### With Content Strategy
+- Blog posts from product content
+- Social proof from product users
+- YouTube videos showcasing techniques
+
+### With Email Marketing
+- Dedicated product sequences
+- Segmentation based on purchases
+- Personalized recommendations
+
+## Risk Mitigation
+
+### Common Pitfalls to Avoid
+1. **Over-promising**: Keep scope focused and deliverable
+2. **Under-pricing**: Don't devalue your expertise
+3. **Poor support**: Set clear expectations upfront
+4. **Feature creep**: Ship MVP, iterate based on feedback
+
+### Quality Assurance
+- Beta test with 10-20 friendly customers
+- Professional editing/design for all materials
+- Clear refund policy (builds trust)
+- Regular updates based on user feedback
+
+## Measuring Success
+
+### Week-by-Week Metrics
+- Week 1: Email survey responses (target: 500+)
+- Week 2: MVP completion and test sales (target: 10)
+- Week 3: Soft launch revenue (target: $2,500)
+- Week 4: Public launch revenue (target: $10,000)
+
+### Monthly KPIs
+- Revenue per product
+- Conversion to subscriptions (target: 10%)
+- Customer satisfaction (target: 4.5+ stars)
+- Refund rate (target: <5%)
+
+## Launch Sequence Timeline
+
+### T-14 Days: Pre-Launch
+- Build anticipation with content
+- Create waiting list
+- Prepare all materials
+
+### T-7 Days: Final Prep
+- Test all systems
+- Brief support team
+- Schedule emails
+
+### T-0: Launch Day
+- 6 AM: Launch email #1
+- Monitor and optimize
+- Respond to questions quickly
+
+### T+7: Optimize
+- Analyze results
+- A/B test elements
+- Plan next product
+
+## Your Next Action
+
+**Start with one thing**: Send a simple email to your list asking:
+
+"What's your biggest challenge with scaling solo? I'm creating something special for you..."
+
+This single action will:
+- Validate demand
+- Build anticipation
+- Guide product development
+- Start your Stream 4 journey
+
+Remember: Perfect is the enemy of profitable. Ship fast, iterate based on feedback, and scale what works.
+
+---
+
+*"The best time to add a revenue stream was last year. The second best time is now."*
+
+**Ready to launch Stream 4? Your future self (and bank account) will thank you.**


### PR DESCRIPTION
I implemented a comprehensive fourth revenue stream for the Unicorn of One project, focused on digital products and resources. I created four key files:

In `content/copy/revenue-stream-4.md`, I outlined the complete strategy for Stream 4, including product lineup ranging from $27-$497, revenue projections, and implementation timeline. The core offering is "The Solo Founder's AI Playbook" at $297.

In `content/copy/ai-playbook-sales-page.md`, I wrote a detailed sales page for the flagship product, including value proposition, features, testimonials, and pricing structure with risk reversal elements.

In `content/copy/ai-playbook-launch-emails.md`, I created a 5-email launch sequence including pre-launch, launch day, social proof, and follow-up emails to drive sales of the AI Playbook.

In `content/copy/stream-4-implementation-guide.md`, I developed a week-by-week action plan for launching Stream 4, including success metrics, risk mitigation, and integration points with existing business operations.

The new revenue stream is designed to complement existing subscription tiers while providing lower-risk entry points for new customers through one-time purchases.